### PR TITLE
Utilities-90 Languagemanager does not call Destroy if Application.isEditor

### DIFF
--- a/Assets/Plugins/LanguageManager/Scripts/Runtime/LanguageManager.cs
+++ b/Assets/Plugins/LanguageManager/Scripts/Runtime/LanguageManager.cs
@@ -68,7 +68,7 @@ namespace GEAR.Localization
                 Instance._xmlSchemaSet.Add("", XmlReader.Create(
                         new MemoryStream(Resources.Load<TextAsset>(XmlSchemaFile).bytes)));
             }
-            else if (Instance != this)
+            else if (Instance != this && !Application.isEditor)
             {
                 Destroy(gameObject);
             }


### PR DESCRIPTION
Close #90 